### PR TITLE
Fixed PhatLoots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.class
+.metadata

--- a/src/me/daddychurchill/CityWorld/Plats/BunkerLot.java
+++ b/src/me/daddychurchill/CityWorld/Plats/BunkerLot.java
@@ -701,7 +701,7 @@ public class BunkerLot extends ConstructLot {
 		
 		// cool stuff?
 		if (generator.settings.treasuresInBunkers && chunkOdds.playOdds(generator.settings.oddsOfTreasureInBunkers)) {
-			 chunk.setChest(x, y, z, Direction.General.NORTH, generator.lootProvider.getItems(generator, chunkOdds, LootLocation.BUNKER));
+			 chunk.setChest(x, y, z, Direction.General.NORTH, chunkOdds, generator.lootProvider, LootLocation.BUNKER);
 		}
 	}
 

--- a/src/me/daddychurchill/CityWorld/Plats/PlatLot.java
+++ b/src/me/daddychurchill/CityWorld/Plats/PlatLot.java
@@ -466,7 +466,7 @@ public abstract class PlatLot {
 
 		// cool stuff?
 		if (generator.settings.treasuresInMines && chunkOdds.playOdds(generator.settings.oddsOfTreasureInMines)) {
-			 chunk.setChest(x, y, z, Direction.General.SOUTH, generator.lootProvider.getItems(generator, chunkOdds, LootLocation.MINE));
+			 chunk.setChest(x, y, z, Direction.General.SOUTH, chunkOdds, generator.lootProvider, LootLocation.MINE);
 		}
 	}
 

--- a/src/me/daddychurchill/CityWorld/Plats/RoadLot.java
+++ b/src/me/daddychurchill/CityWorld/Plats/RoadLot.java
@@ -1302,7 +1302,7 @@ public class RoadLot extends ConnectedLot {
 		
 		// cool stuff?
 		if (generator.settings.treasuresInSewers && chunkOdds.playOdds(generator.settings.oddsOfTreasureInSewers)) {
-			 chunk.setChest(x, y, z, Direction.General.NORTH, generator.lootProvider.getItems(generator, chunkOdds, LootLocation.SEWER));
+			 chunk.setChest(x, y, z, Direction.General.NORTH, chunkOdds, generator.lootProvider, LootLocation.SEWER);
 		}
 	}
 

--- a/src/me/daddychurchill/CityWorld/Plugins/HouseProvider.java
+++ b/src/me/daddychurchill/CityWorld/Plugins/HouseProvider.java
@@ -88,19 +88,18 @@ public class HouseProvider extends Provider {
 	}
 	
 	private void placeShedChest(WorldGenerator generator, RealChunk chunk, Odds odds, int x, int y, int z, Direction.General direction) {
-		chunk.setChest(x, y, z, direction, generator.lootProvider.getItems(generator, odds, LootLocation.STORAGESHED));
 		switch (direction) {
 		case NORTH:
-			chunk.setChest(x + 1, y, z, direction);
+			chunk.setChest(x + 1, y, z, direction, odds, generator.lootProvider, LootLocation.STORAGESHED);
 			break;
 		case SOUTH:
-			chunk.setChest(x - 1, y, z, direction);
+			chunk.setChest(x - 1, y, z, direction, odds, generator.lootProvider, LootLocation.STORAGESHED);
 			break;
 		case WEST:
-			chunk.setChest(x, y, z + 1, direction);
+			chunk.setChest(x, y, z + 1, direction, odds, generator.lootProvider, LootLocation.STORAGESHED);
 			break;
 		case EAST:
-			chunk.setChest(x, y, z - 1, direction);
+			chunk.setChest(x, y, z - 1, direction, odds, generator.lootProvider, LootLocation.STORAGESHED);
 			break;
 		}
 	}

--- a/src/me/daddychurchill/CityWorld/Plugins/LootProvider.java
+++ b/src/me/daddychurchill/CityWorld/Plugins/LootProvider.java
@@ -1,6 +1,7 @@
 package me.daddychurchill.CityWorld.Plugins;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
 import me.daddychurchill.CityWorld.WorldGenerator;
@@ -13,7 +14,7 @@ public abstract class LootProvider extends Provider {
 	
 	public enum LootLocation {SEWER, MINE, BUNKER, STORAGESHED};
 	
-	public abstract ItemStack[] getItems(WorldGenerator generator, Odds odds, LootLocation lootLocation);
+	public void setLoot(Odds odds, LootLocation chestLocation, Block block) {}
 
 	public static LootProvider loadProvider(WorldGenerator generator) {
 
@@ -30,7 +31,7 @@ public abstract class LootProvider extends Provider {
 		return provider;
 	}
 
-	protected ItemStack[] createTreasures(WorldGenerator generator, Odds odds, Material minTreasure, Material maxTreasure, int maxCount, int maxStack) {
+	protected ItemStack[] createTreasures(Odds odds, Material minTreasure, Material maxTreasure, int maxCount, int maxStack) {
 		int minId = minTreasure.getId();
 		int maxId = maxTreasure.getId();
 		int rangeId = maxId - minId + 1;

--- a/src/me/daddychurchill/CityWorld/Plugins/LootProvider_Normal.java
+++ b/src/me/daddychurchill/CityWorld/Plugins/LootProvider_Normal.java
@@ -1,30 +1,39 @@
 package me.daddychurchill.CityWorld.Plugins;
-
-import me.daddychurchill.CityWorld.WorldGenerator;
 import me.daddychurchill.CityWorld.Support.Odds;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 public class LootProvider_Normal extends LootProvider {
 
 	// Based on work contributed by drew-bahrue (https://github.com/echurchill/CityWorld/pull/2)
+	public void setLoot(Odds odds, LootLocation lootLocation, Block block) {
+		Chest chest = (Chest) block.getState();
+		Inventory inv = chest.getInventory();
+		inv.clear();
+		ItemStack[] items = getLoot(odds, lootLocation, block);
+		inv.addItem(items);
+		chest.update(true);
+	}
 	
-	@Override
-	public ItemStack[] getItems(WorldGenerator generator, Odds odds, LootLocation lootLocation) {
+	private ItemStack[] getLoot( Odds odds, LootLocation lootLocation, Block block) {
 
 		// which mix?
 		switch (lootLocation) {
 		case BUNKER:
-			return createTreasures(generator, odds, Material.IRON_SWORD, Material.GOLD_BOOTS, 2, 1);
+			return createTreasures( odds, Material.IRON_SWORD, Material.GOLD_BOOTS, 2, 1);
 		case MINE:
-			return createTreasures(generator, odds, Material.FLINT, Material.ROTTEN_FLESH, 3, 1);
+			return createTreasures( odds, Material.FLINT, Material.ROTTEN_FLESH, 3, 1);
 		case SEWER:
-			return createTreasures(generator, odds, Material.IRON_SPADE, Material.COAL, 3, 2);
+			return createTreasures( odds, Material.IRON_SPADE, Material.COAL, 3, 2);
 		case STORAGESHED:
-			return createTreasures(generator, odds, Material.IRON_SPADE, Material.IRON_AXE, 2, 1);
+			return createTreasures( odds, Material.IRON_SPADE, Material.IRON_AXE, 2, 1);
 		default:
-			return createTreasures(generator, odds, Material.IRON_SPADE, Material.IRON_SPADE, 0, 0);
+			return createTreasures( odds, Material.IRON_SPADE, Material.IRON_SPADE, 0, 0);
 		}
 	}
+	
 }

--- a/src/me/daddychurchill/CityWorld/Plugins/PhatLoot/LootProvider_Phat.java
+++ b/src/me/daddychurchill/CityWorld/Plugins/PhatLoot/LootProvider_Phat.java
@@ -1,81 +1,67 @@
 package me.daddychurchill.CityWorld.Plugins.PhatLoot;
 
-import me.daddychurchill.CityWorld.WorldGenerator;
 import me.daddychurchill.CityWorld.Plugins.LootProvider;
 import me.daddychurchill.CityWorld.Support.Odds;
 
-import org.bukkit.inventory.ItemStack;
+import com.codisimus.plugins.phatloots.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.*;
+import org.bukkit.block.Block;
 
 public class LootProvider_Phat extends LootProvider {
 	
-	public final static String chestInSewers = "CityWorld_Chest_Sewer";
-	public final static String chestInMines = "CityWorld_Chest_Mine";
-	public final static String chestInBunkers = "CityWorld_Chest_Bunker";
-	public final static String chestInStorageShed = "CityWorld_Chest_StorageShed";
-	
 	@Override
-	public ItemStack[] getItems(WorldGenerator generator, Odds odds, LootLocation lootLocation) {
+	public void setLoot(Odds odds, LootLocation lootLocation, Block block) {
+		String name = "CityWorld_" + lootLocation;
+		PhatLoot phatLoot = getByName(name);
+		phatLoot.addChest(block);
+	}
+	
+	private static PhatLoot getByName(String name){
+		PhatLoot phatLoot;
 		
-		// which mix?
-		switch (lootLocation) {
-		case BUNKER:
-			return getItemsByName(generator, chestInBunkers);
-		case MINE:
-			return getItemsByName(generator, chestInMines);
-		case STORAGESHED:
-			return getItemsByName(generator, chestInStorageShed);
-		default: //case SEWER:
-			return getItemsByName(generator, chestInSewers);
-		}
+		if (!PhatLoots.hasPhatLoot(name)) {
+        	PhatLoots.addPhatLoot(new PhatLoot(name));        	
+        }
+		
+		phatLoot = PhatLoots.getPhatLoot(name);
+		phatLoot.save();
+		
+		return phatLoot;
 	}
 
-	public ItemStack[] getItemsByName(WorldGenerator generator, String name) {
-
-		//https://github.com/Codisimus/PhatLoots
-		
-//		PhatLoot phatLoot;
-//		if (!PhatLoots.hasPhatLoot(name)) {
-//        	PhatLoots.addPhatLoot(new PhatLoot(name));        	
-//        }
-//		phatLoot = PhatLoots.getPhatLoot(name);
-//		
-//		phatLoot.chests.add(new PhatLootChest(block));
-//		phatLoot.save();
-		return null;
-		
-	}
-
-//	private static String name = "PhatLoots";
+	private static String name = "PhatLoots";
 	public static LootProvider loadPhatLoots() {
 
-//		PhatLoots phatLoots = null;
-//
-//		PluginManager pm = Bukkit.getServer().getPluginManager();
-//
-//		try {
-//			phatLoots = (PhatLoots) pm.getPlugin(name);
-//		} catch (Exception e) {
-//			CityWorld.reportException(String.format("[LootProvider] Bad Version %s.", name), e);
-//		}
-//
-//		if (phatLoots == null)
+		PhatLoots phatLoots = null;
+
+		PluginManager pm = Bukkit.getServer().getPluginManager();
+
+		try {
+			phatLoots = (PhatLoots) pm.getPlugin(name);
+		} catch (Exception e) {
+			//Exception(String.format("[LootProvider] Bad Version %s.", name), e);
+		}
+
+		if (phatLoots == null)
 			return null;
-//
-//		CityWorld.(String.format("[LootProvider] Found %s.", name));
-//		
-//		try {
-//
-//			if (!pm.isPluginEnabled(phatLoots)) {
-//				CityWorld.reportMessage(String.format("[LootProvider] Enabling %s.", name));
-//				pm.enablePlugin(phatLoots);
-//			}
-//			CityWorld.reportMessage(String.format("[LootProvider] %s Enabled.", name));
-//			
-//			return new LootProvider_PhatLoots();
-//			
-//		} catch (Exception e) {
-//			CityWorld.reportException(String.format("[LootProvider] Failed to enable %s.", name), e);
-//			return null;
-//		}
+
+		//CityWorld.(String.format("[LootProvider] Found %s.", name));
+		
+		try {
+
+			if (!pm.isPluginEnabled(phatLoots)) {
+				//CityWorld.reportMessage(String.format("[LootProvider] Enabling %s.", name));
+				pm.enablePlugin(phatLoots);
+			}
+			//CityWorld.reportMessage(String.format("[LootProvider] %s Enabled.", name));
+			
+			return new LootProvider_Phat();
+			
+		} catch (Exception e) {
+			//CityWorld.reportException(String.format("[LootProvider] Failed to enable %s.", name), e);
+			return null;
+		}
 	}
 }

--- a/src/me/daddychurchill/CityWorld/Plugins/SpawnProvider.java
+++ b/src/me/daddychurchill/CityWorld/Plugins/SpawnProvider.java
@@ -9,7 +9,7 @@ public abstract class SpawnProvider extends Provider {
 
 	// Based on work contributed by drew-bahrue (https://github.com/echurchill/CityWorld/pull/2)
 	
-	public enum SpawnerLocation {SEWER, MINE, BUNKER};
+	public enum SpawnerLocation {SEWER, MINE, BUNKER, HOUSE};
 	
 	public abstract EntityType getEntity(WorldGenerator generator, Odds odds, SpawnerLocation location);
 

--- a/src/me/daddychurchill/CityWorld/Support/RealChunk.java
+++ b/src/me/daddychurchill/CityWorld/Support/RealChunk.java
@@ -2,6 +2,8 @@ package me.daddychurchill.CityWorld.Support;
 
 import me.daddychurchill.CityWorld.WorldGenerator;
 import me.daddychurchill.CityWorld.Context.DataContext;
+import me.daddychurchill.CityWorld.Plugins.LootProvider;
+import me.daddychurchill.CityWorld.Plugins.LootProvider.LootLocation;
 import me.daddychurchill.CityWorld.Support.Direction.Stair;
 import me.daddychurchill.CityWorld.Support.Direction.Torch;
 
@@ -464,17 +466,11 @@ public class RealChunk extends SupportChunk {
 	}
 
 	private final static int chestId = Material.CHEST.getId();
-	public void setChest(int x, int y, int z, Direction.General direction, ItemStack... items) {
+	public void setChest(int x, int y, int z, Direction.General direction, Odds odds, LootProvider lootProvider, LootLocation lootLocation) {
 		Block block = chunk.getBlock(x, y, z);
 		block.setTypeIdAndData(chestId, direction.getData(), false);
-		if (items != null && items.length > 0) {
-			if (block.getTypeId() == chestId) {
-				Chest chest = (Chest) block.getState();
-				Inventory inv = chest.getInventory();
-				inv.clear();
-				inv.addItem(items);
-				chest.update(true);
-			}
+		if (block.getTypeId() == chestId) {
+			lootProvider.setLoot(odds, lootLocation, block);
 		}
 	}
 


### PR DESCRIPTION
Adds chest to PhatLoots instead of populating it with items from PhatLoots. This ensures that the chest stays dynamic after population.
